### PR TITLE
Add authentication and role-based access control

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+python-jose[cryptography]

--- a/src/README.md
+++ b/src/README.md
@@ -5,14 +5,16 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- User registration and login with JWT authentication
+- Role-based access control (`super_admin`, `club_admin`, `member`, `student`)
+- Protected sign-up and unregister actions
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
@@ -27,10 +29,31 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 ## API Endpoints
 
-| Method | Endpoint                                                          | Description                                                         |
-| ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/auth/register` | Register a new user (`student` or `member`) and return JWT |
+| POST | `/auth/login` | Login and return JWT |
+| GET | `/auth/me` | Get current authenticated user from bearer token |
+| GET | `/activities` | Get all activities with details and participants |
+| POST | `/activities/{activity_name}/signup?email=student@mergington.edu` | Protected: sign up for an activity |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Protected: unregister a student from an activity |
+
+## Authentication and Roles
+
+- Public endpoint: `/activities`
+- Protected endpoints require header: `Authorization: Bearer <token>`
+- Self-registration is limited to `student` and `member` roles
+- Seeded users for local testing:
+   - `admin@mergington.edu` / `adminpass123` (`super_admin`)
+   - `clubadmin@mergington.edu` / `clubadmin123` (`club_admin`)
+
+### Role Rules
+
+- `student`, `member`, `club_admin`, `super_admin` can call signup
+- `student` and `member` can only sign up their own email
+- `club_admin` and `super_admin` can unregister students
+- Missing/invalid token returns `401`
+- Insufficient role permissions returns `403`
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,18 +1,104 @@
-"""
-High School Management System API
+"""Mergington High School activities API with authentication and RBAC."""
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
-"""
-
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from datetime import datetime, timedelta, timezone
+import hashlib
 import os
 from pathlib import Path
 
+from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.staticfiles import StaticFiles
+from jose import JWTError, jwt
+from pydantic import BaseModel, Field
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev-only-secret-change-me")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+PASSWORD_SALT = os.getenv("PASSWORD_SALT", "dev-salt")
+
+ROLES = {"super_admin", "club_admin", "member", "student"}
+SELF_SERVICE_ROLES = {"student", "member"}
+
+
+class RegisterRequest(BaseModel):
+    email: str
+    password: str = Field(min_length=8)
+    role: str = "student"
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+def _hash_password(password: str) -> str:
+    return hashlib.sha256(f"{PASSWORD_SALT}{password}".encode("utf-8")).hexdigest()
+
+
+# In-memory user store (temporary until database support is added).
+users = {
+    "admin@mergington.edu": {
+        "email": "admin@mergington.edu",
+        "password_hash": _hash_password("adminpass123"),
+        "role": "super_admin",
+    },
+    "clubadmin@mergington.edu": {
+        "email": "clubadmin@mergington.edu",
+        "password_hash": _hash_password("clubadmin123"),
+        "role": "club_admin",
+    },
+}
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Security(bearer_scheme),
+):
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    token = credentials.credentials
+
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        email: str | None = payload.get("sub")
+        role: str | None = payload.get("role")
+    except JWTError as error:
+        raise HTTPException(status_code=401, detail="Invalid or expired token") from error
+
+    if not email or role not in ROLES:
+        raise HTTPException(status_code=401, detail="Invalid authentication payload")
+
+    return {"email": email, "role": role}
+
+
+def require_roles(allowed_roles: set[str]):
+    def role_dependency(current_user=Depends(get_current_user)):
+        if current_user["role"] not in allowed_roles:
+            raise HTTPException(status_code=403, detail="Insufficient role permissions")
+        return current_user
+
+    return role_dependency
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -78,6 +164,48 @@ activities = {
 }
 
 
+@app.post("/auth/register", response_model=TokenResponse)
+def register_user(request: RegisterRequest):
+    if request.role not in ROLES:
+        raise HTTPException(status_code=400, detail="Invalid role")
+
+    if request.role not in SELF_SERVICE_ROLES:
+        raise HTTPException(
+            status_code=403,
+            detail="Self-registration supports only student or member roles",
+        )
+
+    email = request.email.strip().lower()
+    if email in users:
+        raise HTTPException(status_code=409, detail="User already exists")
+
+    users[email] = {
+        "email": email,
+        "password_hash": _hash_password(request.password),
+        "role": request.role,
+    }
+
+    access_token = create_access_token({"sub": email, "role": request.role})
+    return TokenResponse(access_token=access_token)
+
+
+@app.post("/auth/login", response_model=TokenResponse)
+def login_user(request: LoginRequest):
+    email = request.email.strip().lower()
+    user = users.get(email)
+
+    if not user or user["password_hash"] != _hash_password(request.password):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    access_token = create_access_token({"sub": user["email"], "role": user["role"]})
+    return TokenResponse(access_token=access_token)
+
+
+@app.get("/auth/me")
+def get_me(current_user=Depends(get_current_user)):
+    return current_user
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -89,8 +217,20 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    current_user=Depends(require_roles({"super_admin", "club_admin", "member", "student"})),
+):
     """Sign up a student for an activity"""
+    normalized_email = email.strip().lower()
+
+    if current_user["role"] in {"member", "student"} and current_user["email"] != normalized_email:
+        raise HTTPException(
+            status_code=403,
+            detail="Members and students can only sign up themselves",
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -99,20 +239,26 @@ def signup_for_activity(activity_name: str, email: str):
     activity = activities[activity_name]
 
     # Validate student is not already signed up
-    if email in activity["participants"]:
+    if normalized_email in activity["participants"]:
         raise HTTPException(
             status_code=400,
             detail="Student is already signed up"
         )
 
     # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    activity["participants"].append(normalized_email)
+    return {"message": f"Signed up {normalized_email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    _: dict = Depends(require_roles({"super_admin", "club_admin"})),
+):
     """Unregister a student from an activity"""
+    normalized_email = email.strip().lower()
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -121,12 +267,12 @@ def unregister_from_activity(activity_name: str, email: str):
     activity = activities[activity_name]
 
     # Validate student is signed up
-    if email not in activity["participants"]:
+    if normalized_email not in activity["participants"]:
         raise HTTPException(
             status_code=400,
             detail="Student is not signed up for this activity"
         )
 
     # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    activity["participants"].remove(normalized_email)
+    return {"message": f"Unregistered {normalized_email} from {activity_name}"}

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -13,6 +13,23 @@
     </header>
 
     <main>
+      <section id="auth-container">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-email">Email:</label>
+            <input type="email" id="login-email" required placeholder="admin@mergington.edu" />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" required placeholder="Enter password" />
+          </div>
+          <button type="submit">Login</button>
+          <button type="button" id="logout-btn">Logout</button>
+        </form>
+        <p id="auth-status" class="info">Not logged in</p>
+      </section>
+
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">


### PR DESCRIPTION
## Summary
Implements issue #8 by adding JWT-based authentication and role-based access control to the activities platform.

## Changes
- Added auth endpoints:
  - `POST /auth/register`
  - `POST /auth/login`
  - `GET /auth/me`
- Added role model with: `super_admin`, `club_admin`, `member`, `student`
- Added bearer token auth dependency and role guard helpers
- Protected existing endpoints:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Enforced role behavior:
  - students/members can only sign up themselves
  - only club_admin/super_admin can unregister
- Updated frontend to support login/logout and send bearer token for protected actions
- Updated docs in `src/README.md`
- Added dependency: `python-jose[cryptography]`

## Notes
- User and activity data remain in-memory for now.
- Seeded admin users for local testing are documented in README.